### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         node-version:
-          - lts/* # LTS version
-          - "17" # latest version
+          - lts/*
+          - latest
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
@@ -20,5 +20,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm i
+      - run: npm ci
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,21 @@
 name: Test
-
-on: push
-
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        node-version:
+        node:
           - lts/*
-          - latest
+          - current
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - name: Node ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-
-      - run: npm ci
+          node-version: ${{ matrix.node }}
+      - run: npm install
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pico-framework
 
+[![Build Status](https://github.com/Picolab/pico-framework/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/Picolab/pico-framework/actions/workflows/test.yml)
+
 A framework for building actor-based, people-centric systems. (pico = PersIstent Compute Objects)
 
 ## Why Picos?
@@ -19,7 +21,7 @@ It handles the building blocks of a Pico based system.
   - Rulesets
   - What the ruleset code is allowed to do to a pico i.e. sandboxing
 
-The pico-framework also handles persistence of the pico objects. You can provided the persistance layer via an implementation of [abstract-leveldown](https://github.com/Level/abstract-leveldown)
+The pico-framework also handles persistence of the pico objects. You simply provide the persistence layer via an implementation of [abstract-level](https://github.com/Level/abstract-level).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "@types/abstract-leveldown": "^5.0.1",
     "@types/levelup": "^4.3.0",
     "@types/lodash": "^4.14.157",
-    "ava": "^4.0.0",
+    "ava": "^5.3.1",
     "nyc": "^15.1.0",
     "ts-node": "^10.4.0",
-    "typescript": "^4.5.4"
+    "typescript": "^5.2.2"
   },
   "ava": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -32,25 +32,22 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "rm -rf dist && tsc",
-    "test": "nyc ava"
+    "test": "ava reset-cache && nyc ava"
   },
   "dependencies": {
-    "charwise": "^3.0.1",
+    "abstract-level": "^1.0.3",
     "cuid": "^2.1.8",
-    "encoding-down": "^6.3.0",
-    "level-json-coerce-null": "^1.0.1",
-    "levelup": "^4.4.0",
     "lodash": "^4.17.19",
-    "memdown": "^5.1.0",
-    "select-when": "^0.1.4"
+    "select-when": "^0.1.9"
   },
   "devDependencies": {
-    "@types/abstract-leveldown": "^5.0.1",
-    "@types/levelup": "^4.3.0",
-    "@types/lodash": "^4.14.157",
+    "@types/lodash": "^4.14.201",
     "ava": "^5.3.1",
+    "charwise": "^3.0.1",
+    "level-json-coerce-null": "^1.0.1",
+    "memory-level": "^1.0.0",
     "nyc": "^15.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^5.2.2"

--- a/src/Pico.ts
+++ b/src/Pico.ts
@@ -80,14 +80,17 @@ export class Pico {
 
   private queue: PicoQueue;
 
-  constructor(private pf: PicoFramework, id: string) {
+  constructor(
+    private pf: PicoFramework,
+    id: string,
+  ) {
     this.id = id;
     this.channels[id] = new Channel(this, id, { tags: ["system", "self"] }, id);
 
     this.queue = new PicoQueue(
       this.id,
       this.doTxn.bind(this),
-      (ev: PicoFrameworkEvent) => this.pf.emit(ev)
+      (ev: PicoFrameworkEvent) => this.pf.emit(ev),
     );
   }
 
@@ -152,13 +155,13 @@ export class Pico {
     const child = new Pico(this.pf, this.pf.genID());
     const parentChannel = this.newChannelBase(
       { tags: ["system", "parent"] },
-      child.id
+      child.id,
     );
     child.parent = parentChannel.id;
 
     const childChannel = child.newChannelBase(
       { tags: ["system", "child"] },
-      this.id
+      this.id,
     );
     child.channels[childChannel.id] = childChannel;
     this.children.push(childChannel.id);
@@ -304,7 +307,7 @@ export class Pico {
 
   async newChannel(
     conf?: ChannelConfig,
-    familyChannelPicoID?: string
+    familyChannelPicoID?: string,
   ): Promise<Channel> {
     const chann = this.newChannelBase(conf, familyChannelPicoID);
     await this.pf.db.batch([chann.toDbPut()]);
@@ -314,7 +317,7 @@ export class Pico {
 
   private newChannelBase(
     conf?: ChannelConfig,
-    familyChannelPicoID?: string
+    familyChannelPicoID?: string,
   ): Channel {
     const chann = new Channel(this, this.pf.genID(), conf, familyChannelPicoID);
     return chann;
@@ -364,7 +367,7 @@ export class Pico {
 
   private async installBase(
     rs: Ruleset,
-    config: RulesetConfig = {}
+    config: RulesetConfig = {},
   ): Promise<{ instance: RulesetInstance; dbPut: LevelBatch }> {
     // even if we already have that rid installed, we need to init again
     // b/c the configuration may have changed
@@ -403,7 +406,7 @@ export class Pico {
           key: data.key,
         };
         return delEnt;
-      }
+      },
     );
     ops.push({
       type: "del",
@@ -454,7 +457,7 @@ export class Pico {
     domain: string,
     name: string,
     attrs: PicoEventPayload["attrs"],
-    forRid?: string
+    forRid?: string,
   ) {
     const event = cleanEvent({
       eci: (this.current && this.current.event.eci) || "[raise]",
@@ -515,7 +518,7 @@ export class Pico {
                 // must process one event at a time to maintain the pico's single-threaded guarantee
                 const response = await rs.instance.event(
                   this.current.event,
-                  eid
+                  eid,
                 );
                 responses.push(response);
               }
@@ -532,7 +535,7 @@ export class Pico {
           const qfn = rs?.instance?.query && rs.instance.query[txn.query.name];
           if (!qfn) {
             throw new Error(
-              `Ruleset ${txn.query.rid} does not have query function "${txn.query.name}"`
+              `Ruleset ${txn.query.rid} does not have query function "${txn.query.name}"`,
             );
           }
           const data = await qfn(txn.query, txn.id);

--- a/src/dbRange.ts
+++ b/src/dbRange.ts
@@ -1,44 +1,21 @@
-import { LevelUp } from "levelup";
-import * as _ from "lodash";
+import { AbstractIteratorOptions } from "abstract-level";
+import { PicoDb, PicoDbKey } from "./utils";
 
-export function dbRange<T = any>(
-  ldb: LevelUp,
-  opts: any,
-  onData: (data: any, stop: () => void) => Promise<T> | T
+export async function dbRange<T = any>(
+  db: PicoDb,
+  opts: { prefix?: PicoDbKey },
+  onData: (data: any) => Promise<T> | T,
 ): Promise<T[]> {
-  return new Promise(function(resolve, reject) {
-    const promises: Promise<T>[] = [];
+  const promises: Promise<T>[] = [];
 
-    let hasCalledback = false;
-    function callback(err?: any) {
-      if (hasCalledback) return;
-      hasCalledback = true;
-      if (err) {
-        return reject(err);
-      }
-      Promise.all(promises)
-        .then(resolve)
-        .catch(reject);
-    }
-
-    if (_.has(opts, "prefix")) {
-      opts = _.assign({}, opts, {
-        gte: opts.prefix,
-        lte: opts.prefix.concat([undefined]) // bytewise sorts with null at the bottom and undefined at the top
-      });
-      delete opts.prefix;
-    }
-    const s = ldb.createReadStream(opts);
-    function stopRange() {
-      (s as any).destroy();
-      callback();
-    }
-    s.on("error", function(err) {
-      callback(err);
-    });
-    s.on("end", callback);
-    s.on("data", function(data) {
-      promises.push(Promise.resolve(onData(data, stopRange)));
-    });
-  });
+  let streamOpts: AbstractIteratorOptions<PicoDbKey, any> = {};
+  if (opts && Array.isArray(opts.prefix)) {
+    streamOpts.gte = opts.prefix;
+    streamOpts.lte = opts.prefix.concat([undefined] as any); // bytewise sorts with null at the bottom and undefined at the top
+  }
+  const iter = db.iterator(streamOpts);
+  for await (const [key, value] of iter) {
+    promises.push(Promise.resolve(onData({ key, value })));
+  }
+  return await Promise.all(promises);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,12 @@ import {
 import { PicoQuery } from "./PicoQuery";
 import { Ruleset, RulesetConfig, RulesetInstance } from "./Ruleset";
 import { createRulesetContext, RulesetContext } from "./RulesetContext";
+import { PicoDb, PicoDbKey } from "./utils";
 
 export {
   Pico,
+  PicoDb,
+  PicoDbKey,
   PicoEvent,
   PicoQuery,
   PicoReadOnly,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,9 @@
+import { AbstractLevel, AbstractBatchOperation } from "abstract-level";
+
 export function isNotStringOrBlank(val: any) {
   return typeof val !== "string" || val.trim().length === 0;
 }
 
-/**
- * Copied AbstractBatch from "abstract-leveldown"
- * b/c typescript module resolution doesn't work very well with lerna (used in pico-engine)
- */
-export type LevelBatch = PutBatch | DelBatch;
-type LevelKey = (string | number | null | boolean)[];
-interface PutBatch {
-  readonly type: "put";
-  readonly key: LevelKey;
-  readonly value: any;
-}
-interface DelBatch {
-  readonly type: "del";
-  readonly key: LevelKey;
-}
+export type PicoDbKey = (string | number | null | boolean)[];
+export type PicoDb = AbstractLevel<any, PicoDbKey, any>;
+export type LevelBatch = AbstractBatchOperation<PicoDb, PicoDbKey, any>;

--- a/test/PicoFrameworkEvent.ts
+++ b/test/PicoFrameworkEvent.ts
@@ -2,21 +2,23 @@ import test from "ava";
 import { PicoFramework } from "../src";
 import { PicoFrameworkEvent } from "../src/PicoFrameworkEvent";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
-test("PicoFrameworkEvent", async function(t) {
+test("PicoFrameworkEvent", async function (t) {
   let log: PicoFrameworkEvent[] = [];
 
   let nextId = 0;
 
   const rsReg = rulesetRegistry();
   const pf = new PicoFramework({
+    db: mkdb(),
     rulesetLoader: rsReg.loader,
     genID() {
       return `id${nextId++}`;
     },
     onFrameworkEvent(e) {
       log.push(e);
-    }
+    },
   });
 
   t.deepEqual(log, [{ type: "startup" }]);
@@ -34,7 +36,7 @@ test("PicoFrameworkEvent", async function(t) {
     domain: "one",
     name: "two",
     data: { attrs: {} },
-    time: 0
+    time: 0,
   });
 
   t.is(log.length, 1);
@@ -58,8 +60,8 @@ test("PicoFrameworkEvent", async function(t) {
       txn,
       data: {
         eid: "id2",
-        responses: []
-      }
-    }
+        responses: [],
+      },
+    },
   ]);
 });

--- a/test/clearSchedule.ts
+++ b/test/clearSchedule.ts
@@ -1,13 +1,14 @@
 import test from "ava";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("clearSchedule", async function (t) {
   let log: string[] = [];
 
   const rsReg = rulesetRegistry();
 
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   rsReg.add({
     rid: "rid.A",
     init(ctx) {

--- a/test/ctx_raiseEvent.ts
+++ b/test/ctx_raiseEvent.ts
@@ -1,10 +1,11 @@
 import test from "ava";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("raiseEvent", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
 
   rsReg.add({
@@ -55,7 +56,7 @@ test("raiseEvent", async function (t) {
       rid: "rid.raise",
       name: "history",
       args: {},
-    }
+    },
   );
 
   t.is(history.join("|"), "doing raise|got the raise");
@@ -65,7 +66,7 @@ test("raiseEvent should use cleanEvent", async function (t) {
   const history: any[] = [];
   let ctx: any;
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
   rsReg.add({
     rid: "rid.raise",
@@ -86,8 +87,8 @@ test("raiseEvent should use cleanEvent", async function (t) {
             default:
               history.push(
                 `${event.eci}/${event.domain}:${event.name}?${JSON.stringify(
-                  event.data.attrs
-                )}`
+                  event.data.attrs,
+                )}`,
               );
           }
         },
@@ -122,7 +123,7 @@ test("raiseEvent - forRid", async function (t) {
   let history: string[] = [];
 
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
   rsReg.add({
     rid: "rid.A",

--- a/test/helpers/mkdb.ts
+++ b/test/helpers/mkdb.ts
@@ -1,0 +1,11 @@
+import { MemoryLevel } from "memory-level";
+import { PicoDb, PicoDbKey } from "../../src/utils";
+const charwise = require("charwise");
+const safeJsonCodec = require("level-json-coerce-null");
+
+export function mkdb(): PicoDb {
+  return new MemoryLevel<PicoDbKey, any>({
+    keyEncoding: charwise,
+    valueEncoding: safeJsonCodec,
+  });
+}

--- a/test/helpers/testPicoFramework.ts
+++ b/test/helpers/testPicoFramework.ts
@@ -1,6 +1,7 @@
 import { PicoFramework } from "../../src";
 import { Ruleset } from "../../src/Ruleset";
 import { rulesetRegistry } from "./rulesetRegistry";
+import { mkdb } from "./mkdb";
 
 export async function testPicoFramework(rootRulesets: Ruleset[]) {
   let nextId = 0;
@@ -9,7 +10,11 @@ export async function testPicoFramework(rootRulesets: Ruleset[]) {
   }
 
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader, genID });
+  const pf = new PicoFramework({
+    db: mkdb(),
+    rulesetLoader: rsReg.loader,
+    genID,
+  });
   await pf.start();
 
   for (const rs of rootRulesets) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,10 +2,11 @@ import test from "ava";
 import { isCuid } from "cuid";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("hello world", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
 
   rsReg.add({
@@ -43,7 +44,7 @@ test("hello world", async function (t) {
       name: "hello",
       args: { name: "Bob" },
     }),
-    "Hello Bob!"
+    "Hello Bob!",
   );
 
   t.is(
@@ -53,7 +54,7 @@ test("hello world", async function (t) {
       name: "status",
       args: {},
     }),
-    undefined
+    undefined,
   );
   const eid = await pf.event({
     eci,
@@ -71,7 +72,7 @@ test("hello world", async function (t) {
       name: "status",
       args: {},
     }),
-    "Said hello to Ed with an event."
+    "Said hello to Ed with an event.",
   );
 
   t.is(
@@ -88,9 +89,9 @@ test("hello world", async function (t) {
         rid: "rid.hello",
         name: "status",
         args: {},
-      }
+      },
     ),
-    "Said hello to Jim with an event."
+    "Said hello to Jim with an event.",
   );
 
   let err = await t.throwsAsync(
@@ -99,11 +100,11 @@ test("hello world", async function (t) {
       rid: "rid.hello",
       name: "blah",
       args: {},
-    })
+    }),
   );
   t.is(
     err + "",
-    'Error: Ruleset rid.hello does not have query function "blah"'
+    'Error: Ruleset rid.hello does not have query function "blah"',
   );
 
   err = await t.throwsAsync(
@@ -112,7 +113,7 @@ test("hello world", async function (t) {
       rid: "rid.hello",
       name: "blah",
       args: {},
-    })
+    }),
   );
   t.is(err + "", "Error: ECI not found notreal");
 
@@ -130,15 +131,15 @@ test("hello world", async function (t) {
         rid: "rid.hello",
         name: "status",
         args: {},
-      }
-    )
+      },
+    ),
   );
   t.is(err + "", "Error: eventQuery must use the same channel");
 });
 
 test("pico can pass configuration to rulesets", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
 
   rsReg.add({
@@ -169,7 +170,7 @@ test("pico can pass configuration to rulesets", async function (t) {
       name: "name",
       args: {},
     }),
-    "default name"
+    "default name",
   );
 
   await pico.install(rsReg.get("some.rid"), { name: "Ove" });
@@ -181,13 +182,13 @@ test("pico can pass configuration to rulesets", async function (t) {
       name: "name",
       args: {},
     }),
-    "Ove"
+    "Ove",
   );
 });
 
 test("check channel policies", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
 
   rsReg.add({

--- a/test/persistent.ts
+++ b/test/persistent.ts
@@ -3,11 +3,11 @@ import { PicoFramework } from "../src";
 import { dbRange } from "../src/dbRange";
 import { jsonDumpPico } from "./helpers/inspect";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
-const memdown = require("memdown");
+import { mkdb } from "./helpers/mkdb";
 
 test("persistent", async function (t) {
   // re-use the db on each restart
-  const down = memdown();
+  const db = mkdb();
 
   let nextId = 0;
   function genID() {
@@ -24,8 +24,8 @@ test("persistent", async function (t) {
 
   async function restart(): Promise<PicoFramework> {
     const pf = new PicoFramework({
+      db: db,
       rulesetLoader: rsReg.loader,
-      leveldown: down,
       genID,
     });
     await pf.start();

--- a/test/picoTxnErrors.ts
+++ b/test/picoTxnErrors.ts
@@ -1,10 +1,11 @@
 import test from "ava";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("query error", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   rsReg.add({
     rid: "rid.A",
     init(ctx) {
@@ -27,7 +28,7 @@ test("query error", async function (t) {
   });
 
   let err = await t.throwsAsync(
-    pf.query({ eci: channel.id, rid: "rid.A", name: "error", args: {} })
+    pf.query({ eci: channel.id, rid: "rid.A", name: "error", args: {} }),
   );
   t.is(err + "", "TypeError: ctx.notAFunction is not a function");
 });

--- a/test/reInitRuleset.ts
+++ b/test/reInitRuleset.ts
@@ -1,10 +1,11 @@
 import test from "ava";
 import { PicoFramework, Ruleset } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("reInitRuleset", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   await pf.start();
   const pico = await pf.rootPico;
   const eci = (await pico.newChannel()).id;

--- a/test/ruleset.ts
+++ b/test/ruleset.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("ruleset - eid, qid", async function (t) {
   let log: any[] = [];
@@ -11,7 +12,11 @@ test("ruleset - eid, qid", async function (t) {
   }
 
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader, genID });
+  const pf = new PicoFramework({
+    db: mkdb(),
+    rulesetLoader: rsReg.loader,
+    genID,
+  });
   rsReg.add({
     rid: "rid.A",
     init(ctx, env) {
@@ -73,7 +78,7 @@ test("ruleset - eid, qid", async function (t) {
 
 test("ruleset - responses", async function (t) {
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader });
+  const pf = new PicoFramework({ db: mkdb(), rulesetLoader: rsReg.loader });
   rsReg.add({
     rid: "rid.A",
     init(ctx, env) {

--- a/test/rulesetEnvironment.ts
+++ b/test/rulesetEnvironment.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 import { PicoFramework } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
+import { mkdb } from "./helpers/mkdb";
 
 test("rulesetEnvironment", async function (t) {
   let lastInit: any;
@@ -8,7 +9,11 @@ test("rulesetEnvironment", async function (t) {
   const config = { some: "config" };
 
   const rsReg = rulesetRegistry();
-  const pf = new PicoFramework({ rulesetLoader: rsReg.loader, environment });
+  const pf = new PicoFramework({
+    db: mkdb(),
+    rulesetLoader: rsReg.loader,
+    environment,
+  });
   rsReg.add({
     rid: "rid.A",
     init(ctx, env) {

--- a/test/rulesetStartup.ts
+++ b/test/rulesetStartup.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import { PicoFramework, Ruleset } from "../src";
 import { rulesetRegistry } from "./helpers/rulesetRegistry";
-const memdown = require("memdown");
+import { mkdb } from "./helpers/mkdb";
 
 test("rulesetStartup", async function (t) {
   let errorOnInit = false;
@@ -16,9 +16,9 @@ test("rulesetStartup", async function (t) {
     },
   };
 
-  const down = memdown();
+  const down = mkdb();
   const rsReg = rulesetRegistry();
-  let pf = new PicoFramework({ rulesetLoader: rsReg.loader, leveldown: down });
+  let pf = new PicoFramework({ rulesetLoader: rsReg.loader, db: down });
   rsReg.add(rs);
   await pf.start();
   const pico = await pf.rootPico;
@@ -29,7 +29,7 @@ test("rulesetStartup", async function (t) {
   let swallowedErrors: string[] = [];
   pf = new PicoFramework({
     rulesetLoader: rsReg.loader,
-    leveldown: down,
+    db: down,
     onFrameworkEvent: (e) => {
       switch (e.type) {
         case "startupRulesetInitError":


### PR DESCRIPTION
Breaking change on how the database is setup.

Before: Optional provide a leveldown, and by default would use memdown.
After: Must provide an [abstract-level](https://github.com/Level/abstract-level) implementation that matches the type signature of PicoDb.


For example, creating an in-memory db:

```ts
import { MemoryLevel } from "memory-level";
import { PicoFramework, PicoDb, PicoDbKey, RulesetLoader } from "pico-framework";
const charwise = require("charwise");
const safeJsonCodec = require("level-json-coerce-null");

const db: PicoDb = new MemoryLevel<PicoDbKey, any>({
  keyEncoding: charwise,
  valueEncoding: safeJsonCodec,
});

const rulesetLoader: RulesetLoader = ...

const pf = new PicoFramework({ db, rulesetLoader })
await pf.start()
```